### PR TITLE
Updating schema.sql

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -33,15 +33,23 @@ CREATE TABLE user (
     FOREIGN KEY (role_id) REFERENCES role (id)
 );
 
+-- Favoris (utilisateur)
 CREATE TABLE favorite (
     user_id INT UNSIGNED,
     video_id INT UNSIGNED,
     FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE,
     FOREIGN KEY (video_id) REFERENCES video (id) ON DELETE CASCADE
-)
+);
+
+-- Favoris (admin) -> heroslider
+CREATE TABLE heroslider (
+    id INT UNSIGNED PRIMARY KEY AUTO_INCREMENT NOT NULL,
+    video_id INT UNSIGNED,
+    FOREIGN KEY (video_id) REFERENCES video (id) ON DELETE CASCADE
+);
 
 -- Création de roles
 INSERT INTO role (name) VALUES ('user'), ('admin');
 
--- Création de catégories "exemples"
+-- Création de catégories par défaut
 INSERT INTO category (name) VALUES ('Animals'), ('Sports'), ('Music'), ('Education'), ('Entertainment');

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1,4 +1,3 @@
--- SQLBook: Code
 -- Catégorie
 CREATE TABLE category (
     id INT UNSIGNED PRIMARY KEY AUTO_INCREMENT NOT NULL,
@@ -34,20 +33,16 @@ CREATE TABLE user (
     FOREIGN KEY (role_id) REFERENCES role (id)
 );
 
-CREATE TABLE payment (
-    id INT UNSIGNED PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    date DATE NOT NULL,
-    type VARCHAR(40) NOT NULL,
+CREATE TABLE favorite (
     user_id INT UNSIGNED,
-    FOREIGN KEY (user_id) REFERENCES user (id)
-);
-
-CREATE TABLE privilege (
     video_id INT UNSIGNED,
-    user_id INT UNSIGNED,
-    FOREIGN KEY (video_id) REFERENCES video (id),
-    FOREIGN KEY (user_id) REFERENCES user (id)
-);
+    is_favorite BOOLEAN DEFAULT FALSE,
+    FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE,
+    FOREIGN KEY (video_id) REFERENCES video (id) ON DELETE CASCADE
+)
 
 -- Création de roles
 INSERT INTO role (name) VALUES ('user'), ('admin');
+
+-- Création de catégories "exemples"
+INSERT INTO category (name) VALUES ('Animals'), ('Sports'), ('Music'), ('Education'), ('Entertainment');

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -36,7 +36,6 @@ CREATE TABLE user (
 CREATE TABLE favorite (
     user_id INT UNSIGNED,
     video_id INT UNSIGNED,
-    is_favorite BOOLEAN DEFAULT FALSE,
     FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE,
     FOREIGN KEY (video_id) REFERENCES video (id) ON DELETE CASCADE
 )


### PR DESCRIPTION
Updating `schema.sql` in anticipation of the addition of favorites

- added default categories
  > ℹ️ I added them to be able to do `npm run db:migrate && npm run db:seed` at once (they can always be renamed from the admin panel afterward)
- removed obsolete tables (`payment` and `privilege`)
  > ❌ payments won't be implemented (or simulated) as previously discussed and user access restrictions have already been implemented without the need for an extra table
- added `favorite` table
  > ℹ️ does nothing for now, to be implemented in order to change the heroslider's videos as an admin (as per the original user story)
  > ℹ️ **to be clear**: the `heroslider` table handles the admin's favorites which controls what videos appear on the heroslider, the `favorite` table is for the users' favorites
  > also I believe we need a junction table for the title (?), so far we only have "many to one" relations and not a single "many to many"
  > otherwise we could always implement user comments to fill the gap ?