### PR TITLE
little navbar "fix"

### DIFF
--- a/client/src/components/navbar/NavBar.jsx
+++ b/client/src/components/navbar/NavBar.jsx
@@ -88,17 +88,20 @@ export default function NavBar({ user, setUser }) {
               </li>
             )}
             {user === null ? (
-              <li>
-                <Link to="login">
-                  <LogInIcon />
-                  {" Login"}
-                </Link>
-                {" or "}
-                <Link to="signup">
-                  <UserRoundPlusIcon />
-                  {" Signup"}
-                </Link>
-              </li>
+              <>
+                <li>
+                  <Link to="login">
+                    <LogInIcon />
+                    {" Login"}
+                  </Link>
+                </li>
+                <li>
+                  <Link to="signup">
+                    <UserRoundPlusIcon />
+                    {" Signup"}
+                  </Link>
+                </li>
+              </>
             ) : (
               <li>
                 <button type="button" onClick={handleLogout} className="logout">


### PR DESCRIPTION
`Login` and `Signup` are now separated in the navbar, this alleviates the "off-center" look that `Categories` had before since the list element they were inside of was twice as big as the other ones