### PR TITLE
fix: add heroslider on adminpage

### DIFF
--- a/client/src/components/HeroSlider/HeroSlider.css
+++ b/client/src/components/HeroSlider/HeroSlider.css
@@ -2,3 +2,15 @@
   margin-top: 2rem;
   margin-bottom: 2.5rem;
 }
+
+#heroSlide {
+  position: relative;
+}
+
+button:has(> .trashIcon) {
+  background-color: transparent;
+  border: none;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+}

--- a/client/src/components/HeroSlider/HeroSlider.jsx
+++ b/client/src/components/HeroSlider/HeroSlider.jsx
@@ -13,10 +13,7 @@ import "swiper/css";
 import "swiper/css/pagination";
 import "swiper/css/navigation";
 
-export default function HeroSlider({
-  numberOfSlides = null,
-  currentUser = null,
-}) {
+export default function HeroSlider({ numberOfSlides = null }) {
   const [videoData, setVideoData] = useState([]);
 
   useEffect(() => {
@@ -45,7 +42,7 @@ export default function HeroSlider({
     } catch (err) {
       if (err) toast.error("Error when fetching data");
     }
-  }, [currentUser]);
+  }, []);
 
   return (
     <Swiper
@@ -85,12 +82,5 @@ export default function HeroSlider({
 }
 
 HeroSlider.propTypes = {
-  numberOfSlides: PropTypes.number.isRequired,
-  currentUser: PropTypes.shape({
-    firstname: PropTypes.string.isRequired,
-    lastname: PropTypes.string.isRequired,
-    email: PropTypes.string.isRequired,
-    role: PropTypes.string.isRequired,
-    id: PropTypes.number.isRequired,
-  }),
+  numberOfSlides: PropTypes.number,
 };

--- a/client/src/components/HeroSlider/HeroSlider.jsx
+++ b/client/src/components/HeroSlider/HeroSlider.jsx
@@ -7,17 +7,19 @@ import axios from "axios";
 import { NavLink } from "react-router-dom";
 import PropTypes from "prop-types";
 import { toast } from "react-toastify";
+import { Trash2Icon } from "lucide-react";
 
 import "./HeroSlider.css";
 import "swiper/css";
 import "swiper/css/pagination";
 import "swiper/css/navigation";
 
-export default function HeroSlider({ numberOfSlides = null }) {
+export default function HeroSlider({ numberOfSlides = null, admin = false }) {
   const [videoData, setVideoData] = useState([]);
 
+  const express = import.meta.env.VITE_API_URL;
+
   useEffect(() => {
-    const express = import.meta.env.VITE_API_URL;
     try {
       const fetchHerosliderVideos = async () => {
         const data = await axios
@@ -42,7 +44,7 @@ export default function HeroSlider({ numberOfSlides = null }) {
     } catch (err) {
       if (err) toast.error("Error when fetching data");
     }
-  }, []);
+  }, [express]);
 
   return (
     <Swiper
@@ -70,11 +72,33 @@ export default function HeroSlider({ numberOfSlides = null }) {
       className="heroSwiper"
       id="heroSwiper"
     >
-      {videoData.slice(0, 5).map((v) => (
+      {videoData.map((v) => (
         <SwiperSlide key={v.title} id="heroSlide">
           <NavLink to={`/video/${v.id}`}>
             <img id="imageHero" src={v.image} alt={v.title} />
           </NavLink>
+          {admin && (
+            <button type="button" aria-label="Remove from slider">
+              <Trash2Icon
+                className="trashIcon"
+                color="#2B2929"
+                fill="#1FD360"
+                onClick={() => {
+                  axios
+                    .delete(`${express}/api/heroslider/${v.id}`)
+                    .then((response) => {
+                      if (response.status === 204) {
+                        toast.success(
+                          "Video successfully removed from the heroslider"
+                        );
+                        videoData.splice(videoData.indexOf(v), 1);
+                        setVideoData([...videoData]);
+                      }
+                    });
+                }}
+              />
+            </button>
+          )}
         </SwiperSlide>
       ))}
     </Swiper>
@@ -83,4 +107,5 @@ export default function HeroSlider({ numberOfSlides = null }) {
 
 HeroSlider.propTypes = {
   numberOfSlides: PropTypes.number,
+  admin: PropTypes.bool,
 };

--- a/client/src/pages/adminpage/AdminPage.jsx
+++ b/client/src/pages/adminpage/AdminPage.jsx
@@ -12,7 +12,7 @@ import HeroSlider from "../../components/HeroSlider/HeroSlider";
 export default function AdminPage() {
   const currentUser = useLoaderData();
 
-  return currentUser.role !== "admin" || !currentUser ? (
+  return currentUser?.role !== "admin" || !currentUser ? (
     <Navigate to="/" />
   ) : (
     <>
@@ -36,11 +36,11 @@ export default function AdminPage() {
         </section>
       </div>
 
-      <hr style={{ margin: "3rem 0" }} />
+      <hr style={{ margin: "3rem 0", borderStyle: "dashed" }} />
 
       <div className="admin-panel-heroslider">
         <h2> Hero Slider</h2>
-        <HeroSlider />
+        <HeroSlider admin />
       </div>
     </>
   );

--- a/client/src/pages/adminpage/AdminPage.jsx
+++ b/client/src/pages/adminpage/AdminPage.jsx
@@ -35,6 +35,9 @@ export default function AdminPage() {
           </article>
         </section>
       </div>
+
+      <hr style={{ margin: "3rem 0" }} />
+
       <div className="admin-panel-heroslider">
         <h2> Hero Slider</h2>
         <HeroSlider />

--- a/client/src/pages/adminpage/AdminPage.jsx
+++ b/client/src/pages/adminpage/AdminPage.jsx
@@ -7,6 +7,7 @@ import CategoryDelete from "../../components/categoryforms/CategoryDelete";
 import "./AdminPage.css";
 import VideoUpdate from "../../components/videoforms/VideoUpdate";
 import CategoryUpdate from "../../components/categoryforms/CategoryUpdate";
+import HeroSlider from "../../components/HeroSlider/HeroSlider";
 
 export default function AdminPage() {
   const currentUser = useLoaderData();
@@ -33,6 +34,10 @@ export default function AdminPage() {
             <CategoryDelete />
           </article>
         </section>
+      </div>
+      <div className="admin-panel-heroslider">
+        <h2> Hero Slider</h2>
+        <HeroSlider />
       </div>
     </>
   );

--- a/client/src/pages/signupPage/SignupPage.css
+++ b/client/src/pages/signupPage/SignupPage.css
@@ -45,6 +45,12 @@
   }
 }
 
+.signup-form > label {
+  align-self: baseline;
+  position: relative;
+  left: 1rem;
+}
+
 .signup-subtitle {
   color: black;
   font-size: 1rem;


### PR DESCRIPTION
small PR to add heroslider to the admin page to look like the templates:
- heroslider now present in the `AdminPage`
- each video in the heroslider has a button to remove it directly from the heroslider
also:
- removed the _now_ useless `CurrentUser` props from the heroslider
- fixed labels on SignupPage being centered when they shouldn't be